### PR TITLE
feat: IP_OR_DOMAIN matcher - e.g. IP or DNS multiaddrs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -348,23 +348,23 @@ const _IP = or(
   _IP6
 )
 
-const IP_OR_DOMAIN = or(_IP, _DNS, _DNS4, _DNS6, _DNSADDR)
+const _IP_OR_DOMAIN = or(_IP, _DNS, _DNS4, _DNS6, _DNSADDR)
 
 /**
- * Matches routable addresses - addresses that start with IP or DNS tuples.
+ * A matcher for addresses that start with IP or DNS tuples.
  *
  * @example
  *
  * ```ts
  * import { multiaddr } from '@multiformats/multiaddr'
- * import { ROUTABLE } from '@multiformats/multiaddr-matcher'
+ * import { IP_OR_DOMAIN } from '@multiformats/multiaddr-matcher'
  *
- * const ma = multiaddr('/ip4/123.123.123.123')
- *
- * ROUTABLE.matches(ma) // true
+ * IP_OR_DOMAIN.matches(multiaddr('/ip4/123.123.123.123/p2p/QmFoo')) // true
+ * IP_OR_DOMAIN.matches(multiaddr('/dns/example.com/p2p/QmFoo')) // true
+ * IP_OR_DOMAIN.matches(multiaddr('/p2p/QmFoo')) // false
  * ```
  */
-export const ROUTABLE = fmt(IP_OR_DOMAIN)
+export const IP_OR_DOMAIN = fmt(_IP_OR_DOMAIN)
 
 /**
  * Matches ip4 addresses.
@@ -417,8 +417,8 @@ export const IP6 = fmt(_IP6)
  */
 export const IP = fmt(_IP)
 
-const _TCP = and(IP_OR_DOMAIN, literal('tcp'), number())
-const _UDP = and(IP_OR_DOMAIN, literal('udp'), number())
+const _TCP = and(_IP_OR_DOMAIN, literal('tcp'), number())
+const _UDP = and(_IP_OR_DOMAIN, literal('udp'), number())
 
 const TCP_OR_UDP = or(_TCP, _UDP)
 
@@ -484,7 +484,7 @@ export const QUIC = fmt(_QUIC)
 export const QUICV1 = fmt(_QUICV1)
 
 const _WEB = or(
-  IP_OR_DOMAIN,
+  _IP_OR_DOMAIN,
   _TCP,
   _UDP,
   _QUIC,
@@ -565,7 +565,7 @@ const _P2P = or(
   _WebSocketsSecure,
   and(_TCP, optional(peerId())),
   and(QUIC_V0_OR_V1, optional(peerId())),
-  and(IP_OR_DOMAIN, optional(peerId())),
+  and(_IP_OR_DOMAIN, optional(peerId())),
   _WebRTCDirect,
   _WebTransport,
   peerId()

--- a/src/index.ts
+++ b/src/index.ts
@@ -351,6 +351,22 @@ const _IP = or(
 const IP_OR_DOMAIN = or(_IP, _DNS, _DNS4, _DNS6, _DNSADDR)
 
 /**
+ * Matches routable addresses - addresses that start with IP or DNS tuples.
+ *
+ * @example
+ *
+ * ```ts
+ * import { multiaddr } from '@multiformats/multiaddr'
+ * import { ROUTABLE } from '@multiformats/multiaddr-matcher'
+ *
+ * const ma = multiaddr('/ip4/123.123.123.123')
+ *
+ * ROUTABLE.matches(ma) // true
+ * ```
+ */
+export const ROUTABLE = fmt(IP_OR_DOMAIN)
+
+/**
  * Matches ip4 addresses.
  *
  * Use {@link IP IP} instead to match any ip4/ip6 address.

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -238,18 +238,18 @@ describe('multiaddr matcher', () => {
     '/ip4/10.5.0.2/udp/4001/quic-v1/webtransport/p2p/12D3KooWQF6Q3i1QkziJQ9mkNNcyFD8GPQz6R6oEvT75wgsVXm4v'
   ]
 
-  const exactRoutable = [
+  const exactIPorDomain = [
     ...exactDNS,
     ...exactIP
   ]
 
-  const goodRoutable = [
-    ...exactRoutable,
+  const goodIPorDomain = [
+    ...exactIPorDomain,
     ...exactDNS,
     ...exactIP
   ]
 
-  const badRoutable = [
+  const badIPorDomain = [
     '/webrtc/p2p/12D3KooWQF6Q3i1QkziJQ9mkNNcyFD8GPQz6R6oEvT75wgsVXm4v',
     '/quic',
     '/unix/var/log'
@@ -345,9 +345,9 @@ describe('multiaddr matcher', () => {
     assertMismatches(mafmt.WebTransport, badWebTransport)
   })
 
-  it('Routable addresses', () => {
-    assertMatches(mafmt.ROUTABLE, goodRoutable)
-    assertExactMatches(mafmt.ROUTABLE, exactRoutable)
-    assertMismatches(mafmt.ROUTABLE, badRoutable)
+  it('IP or Domain addresses', () => {
+    assertMatches(mafmt.IP_OR_DOMAIN, goodIPorDomain)
+    assertExactMatches(mafmt.IP_OR_DOMAIN, exactIPorDomain)
+    assertMismatches(mafmt.IP_OR_DOMAIN, badIPorDomain)
   })
 })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -238,6 +238,23 @@ describe('multiaddr matcher', () => {
     '/ip4/10.5.0.2/udp/4001/quic-v1/webtransport/p2p/12D3KooWQF6Q3i1QkziJQ9mkNNcyFD8GPQz6R6oEvT75wgsVXm4v'
   ]
 
+  const exactRoutable = [
+    ...exactDNS,
+    ...exactIP
+  ]
+
+  const goodRoutable = [
+    ...exactRoutable,
+    ...exactDNS,
+    ...exactIP
+  ]
+
+  const badRoutable = [
+    '/webrtc/p2p/12D3KooWQF6Q3i1QkziJQ9mkNNcyFD8GPQz6R6oEvT75wgsVXm4v',
+    '/quic',
+    '/unix/var/log'
+  ]
+
   function assertMatches (p: MultiaddrMatcher, ...tests: string[][]): void {
     tests.forEach((test) => {
       test.forEach((testcase) => {
@@ -326,5 +343,11 @@ describe('multiaddr matcher', () => {
   it('WebTransport addresses', () => {
     assertMatches(mafmt.WebTransport, goodWebTransport)
     assertMismatches(mafmt.WebTransport, badWebTransport)
+  })
+
+  it('Routable addresses', () => {
+    assertMatches(mafmt.ROUTABLE, goodRoutable)
+    assertExactMatches(mafmt.ROUTABLE, exactRoutable)
+    assertMismatches(mafmt.ROUTABLE, badRoutable)
   })
 })


### PR DESCRIPTION
Adds matchers for multiaddrs that start with IP or DNS tuples.