### PR TITLE
fix: make webrtc-direct certhashes optional and require udp

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -420,8 +420,6 @@ export const IP = fmt(_IP)
 const _TCP = and(_IP_OR_DOMAIN, literal('tcp'), number())
 const _UDP = and(_IP_OR_DOMAIN, literal('udp'), number())
 
-const TCP_OR_UDP = or(_TCP, _UDP)
-
 /**
  * Matches TCP addresses.
  *
@@ -528,7 +526,7 @@ const _WebSocketsSecure = or(
  */
 export const WebSocketsSecure = fmt(_WebSocketsSecure)
 
-const _WebRTCDirect = and(TCP_OR_UDP, literal('webrtc-direct'), certhash(), optional(certhash()), optional(peerId()))
+const _WebRTCDirect = and(_UDP, literal('webrtc-direct'), optional(certhash()), optional(certhash()), optional(peerId()))
 
 /**
  * Matches WebRTC-direct addresses.

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -196,17 +196,17 @@ describe('multiaddr matcher', () => {
   ]
 
   const goodWebRTCDirect = [
-    '/ip4/0.0.0.0/tcp/4004/webrtc-direct/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw',
-    '/ip4/0.0.0.0/tcp/4004/webrtc-direct/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64',
-    '/ip4/0.0.0.0/tcp/4004/webrtc-direct/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64',
+    '/ip4/0.0.0.0/udp/4004/webrtc-direct',
     '/ip4/0.0.0.0/udp/4004/webrtc-direct/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw',
     '/ip4/0.0.0.0/udp/4004/webrtc-direct/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64',
     '/ip4/0.0.0.0/udp/4004/webrtc-direct/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64'
   ]
 
   const badWebRTCDirect = [
-    '/ip4/0.0.0.0/udp/4004/webrtc-direct',
-    '/ip4/0.0.0.0/tcp/4004/webrtc-direct'
+    '/ip4/0.0.0.0/tcp/4004/webrtc-direct',
+    '/ip4/0.0.0.0/tcp/4004/webrtc-direct/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw',
+    '/ip4/0.0.0.0/tcp/4004/webrtc-direct/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64',
+    '/ip4/0.0.0.0/tcp/4004/webrtc-direct/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/certhash/uEiAeP0OEmBbGVTH5Bhnm3WopwRNSQ0et46xNkn2dIagnGw/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64'
   ]
 
   const goodWebRTC = [


### PR DESCRIPTION
Browsers cannot make TCP connections so they must be UDP as per the spec.

Also certhashes must be optional to allow listening on webrtc-direct addresses.