### PR TITLE
feat: support sni tuple in wss multiaddr

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -309,8 +309,7 @@ export const WebSockets = fmt(_WebSockets)
 
 const _WebSocketsSecure = or(
   and(_WEB, literal('wss'), optional(peerId())),
-  and(_WEB, literal('tls'), literal('ws'), optional(peerId())),
-  and(_TCP, literal('tls'), literal('sni'), string(), literal('ws'), optional(peerId()))
+  and(_WEB, literal('tls'), optional(literal('sni'), string()), literal('ws'), optional(peerId()))
 )
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -309,7 +309,8 @@ export const WebSockets = fmt(_WebSockets)
 
 const _WebSocketsSecure = or(
   and(_WEB, literal('wss'), optional(peerId())),
-  and(_WEB, literal('tls'), literal('ws'), optional(peerId()))
+  and(_WEB, literal('tls'), literal('ws'), optional(peerId())),
+  and(_TCP, literal('tls'), literal('sni'), string(), literal('ws'), optional(peerId()))
 )
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -309,7 +309,7 @@ export const WebSockets = fmt(_WebSockets)
 
 const _WebSocketsSecure = or(
   and(_WEB, literal('wss'), optional(peerId())),
-  and(_WEB, literal('tls'), optional(literal('sni'), string()), literal('ws'), optional(peerId()))
+  and(_WEB, literal('tls'), optional(and(literal('sni'), string())), literal('ws'), optional(peerId()))
 )
 
 /**

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -138,11 +138,7 @@ describe('multiaddr matcher', () => {
     '/dns4/ipfs.io/tls/ws/p2p/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79',
     '/dns6/ipfs.io/tls/ws/p2p/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79',
     '/ip4/1.2.3.4/tcp/3456/tls/ws/p2p/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79',
-    '/ip6/::/tcp/3456/tls/ws/p2p/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79'
-  ]
-
-  const goodWSS = [
-    ...exactWSS,
+    '/ip6/::/tcp/3456/tls/ws/p2p/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79',
     '/ip4/147.75.87.65/tcp/4002/tls/sni/147-75-87-65.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/ws',
     '/ip4/147.75.87.65/tcp/4002/tls/sni/147-75-87-65.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/ws/p2p/12D3KooWDpp7U7W9Q8feMZPPEpPP5FKXTUakLgnVLbavfjb9mzrT',
     '/dns4/147-75-80-75.k51qzi5uqu5dho0o9zm90239gjuacg6q1s69e0l1k5ow6kna869fsyb7ukjpeg.libp2p.direct/tcp/4002/tls/ws',
@@ -155,6 +151,10 @@ describe('multiaddr matcher', () => {
     '/dns6/2604-1380-4601-f600--1.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/tcp/4002/tls/ws/p2p/12D3KooWDpp7U7W9Q8feMZPPEpPP5FKXTUakLgnVLbavfjb9mzrT',
     '/dns/2604-1380-4601-f600--1.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/tcp/4002/tls/ws',
     '/dns/2604-1380-4601-f600--1.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/tcp/4002/tls/ws/p2p/12D3KooWDpp7U7W9Q8feMZPPEpPP5FKXTUakLgnVLbavfjb9mzrT'
+  ]
+
+  const goodWSS = [
+    ...exactWSS
   ]
 
   const badWS = [

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -142,7 +142,19 @@ describe('multiaddr matcher', () => {
   ]
 
   const goodWSS = [
-    ...exactWSS
+    ...exactWSS,
+    '/ip4/147.75.87.65/tcp/4002/tls/sni/147-75-87-65.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/ws',
+    '/ip4/147.75.87.65/tcp/4002/tls/sni/147-75-87-65.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/ws/p2p/12D3KooWDpp7U7W9Q8feMZPPEpPP5FKXTUakLgnVLbavfjb9mzrT',
+    '/dns4/147-75-80-75.k51qzi5uqu5dho0o9zm90239gjuacg6q1s69e0l1k5ow6kna869fsyb7ukjpeg.libp2p.direct/tcp/4002/tls/ws',
+    '/dns4/147-75-80-75.k51qzi5uqu5dho0o9zm90239gjuacg6q1s69e0l1k5ow6kna869fsyb7ukjpeg.libp2p.direct/tcp/4002/tls/ws/p2p/12D3KooWDpp7U7W9Q8feMZPPEpPP5FKXTUakLgnVLbavfjb9mzrT',
+    '/dns/147-75-87-65.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/tcp/4002/tls/ws',
+    '/dns/147-75-87-65.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/tcp/4002/tls/ws/p2p/12D3KooWDpp7U7W9Q8feMZPPEpPP5FKXTUakLgnVLbavfjb9mzrT',
+    '/ip6/2604:1380:4601:f600::1/tcp/4002/tls/sni/2604-1380-4601-f600--1.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/ws',
+    '/ip6/2604:1380:4601:f600::1/tcp/4002/tls/sni/2604-1380-4601-f600--1.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/ws/p2p/12D3KooWDpp7U7W9Q8feMZPPEpPP5FKXTUakLgnVLbavfjb9mzrT',
+    '/dns6/2604-1380-4601-f600--1.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/tcp/4002/tls/ws',
+    '/dns6/2604-1380-4601-f600--1.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/tcp/4002/tls/ws/p2p/12D3KooWDpp7U7W9Q8feMZPPEpPP5FKXTUakLgnVLbavfjb9mzrT',
+    '/dns/2604-1380-4601-f600--1.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/tcp/4002/tls/ws',
+    '/dns/2604-1380-4601-f600--1.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/tcp/4002/tls/ws/p2p/12D3KooWDpp7U7W9Q8feMZPPEpPP5FKXTUakLgnVLbavfjb9mzrT'
   ]
 
   const badWS = [


### PR DESCRIPTION
~~Not sure whether we want these addrs to appear in `exactWSS` or `goodWSS`~~


When testing https://github.com/ipfs/service-worker-gateway/pull/405, I noticed that js-libp2p was failing to calculate whether multiaddrs were dialable or not.

We received two provider multiaddrs for a CID:

```json
[
    "/ip4/147.75.87.65/tcp/4002/tls/sni/147-75-87-65.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/ws",
    "/ip6/2604:1380:4601:f600::1/tcp/4002/tls/sni/2604-1380-4601-f600--1.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/ws"
]
```

the libp2p.direct addrs were being filtered out in https://github.com/libp2p/js-libp2p/blob/717731e49a40142164af6c5c5703f0cad32edbe5/packages/transport-websockets/src/index.ts#L202-L215 and resulting in an error in the console: `libp2p:connection-manager:dial-queue:trace error calculating if multiaddr(s) were dialable +4m NoValidAddressesError: The dial request has no valid addresses`