### PR TITLE
feat: add unix address matchers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -489,6 +489,7 @@ const _Memory = or(
  * @example
  *
  * ```ts
+ * import { multiaddr } from '@multiformats/multiaddr'
  * import { Memory } from '@multiformats/multiaddr-matcher'
  *
  * Memory.matches(multiaddr('/memory/0xDEADBEEF')) // true

--- a/src/index.ts
+++ b/src/index.ts
@@ -460,3 +460,21 @@ const _HTTPS = or(
  * ```
  */
 export const HTTPS = fmt(_HTTPS)
+
+const _Unix = or(
+  and(literal('unix'), string(), optional(peerId()))
+)
+
+/**
+ * Matches Unix addresses
+ *
+ * @example
+ *
+ * ```ts
+ * import { multiaddr } from '@multiformats/multiaddr'
+ * import { Unix } from '@multiformats/multiaddr-matcher'
+ *
+ * Unix.matches(multiaddr('/unix/%2Fpath%2Fto%2Funix.socket')) // true
+ * ```
+ */
+export const Unix = fmt(_Unix)

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -309,6 +309,19 @@ describe('multiaddr matcher', () => {
     '/ip4/0.0.0.0/udp/80/http'
   ]
 
+  const exactUnix = [
+    '/unix/%2Fpath%2Fto%2Funix.socket',
+    '/unix/%2Fpath%2Fto%2Funix.socket/p2p/12D3KooWQF6Q3i1QkziJQ9mkNNcyFD8GPQz6R6oEvT75wgsVXm4v'
+  ]
+
+  const goodUnix = [
+    ...exactUnix
+  ]
+
+  const badUnix = [
+    '/ip4/0.0.0.0/tcp/0/https'
+  ]
+
   function assertMatches (p: MultiaddrMatcher, ...tests: string[][]): void {
     tests.forEach((test) => {
       test.forEach((testcase) => {
@@ -415,5 +428,11 @@ describe('multiaddr matcher', () => {
     assertMatches(mafmt.HTTPS, goodHTTPS)
     assertExactMatches(mafmt.HTTPS, exactHTTPS)
     assertMismatches(mafmt.HTTPS, badHTTPS)
+  })
+
+  it('Unix addresses', () => {
+    assertMatches(mafmt.Unix, goodUnix)
+    assertExactMatches(mafmt.Unix, exactUnix)
+    assertMismatches(mafmt.Unix, badUnix)
   })
 })


### PR DESCRIPTION
Need to resolve how to encode unix paths so peer ids can be appended to them - https://github.com/multiformats/multiaddr/pull/174