### PR TITLE
fix: support ../tcp/1234/tls/http multiaddrs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -458,7 +458,8 @@ export const HTTP = fmt(_HTTP)
 const _HTTPS = or(
   and(_IP_OR_DOMAIN, literal('tcp'), or(
     and(literal('443'), literal('http')),
-    and(number(), literal('https'))
+    and(number(), literal('https')),
+    and(number(), literal('tls'), literal('http'))
   ), optional(peerId())),
   and(_IP_OR_DOMAIN, literal('tls'), literal('http'), optional(peerId())),
   and(_IP_OR_DOMAIN, literal('https'), optional(peerId()))

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -328,6 +328,8 @@ describe('multiaddr matcher', () => {
     '/dns6/example.org/tcp/443/http',
     '/dnsaddr/example.org/tcp/443/http',
     '/dns/example.org/tcp/443/http',
+    '/dns/example.org/tcp/7777/tls/http',
+    '/dns/example.org/tcp/443/tls/http',
     '/dns4/example.org/tls/http',
     '/dns/example.org/tls/http/p2p/12D3KooWQF6Q3i1QkziJQ9mkNNcyFD8GPQz6R6oEvT75wgsVXm4v'
   ]


### PR DESCRIPTION
Recognise these types of multiaddrs as HTTPS