### PR TITLE
fix!: update @multiformats/multiaddr to 13.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "docs": "aegir docs"
   },
   "dependencies": {
-    "@multiformats/multiaddr": "^12.0.0"
+    "@multiformats/multiaddr": "^13.0.0"
   },
   "devDependencies": {
     "aegir": "^47.0.19"


### PR DESCRIPTION
Updates to the latest version of the library.

BREAKING CHANGE: Requires use 13.x.x of @multiformats/multiaddr