### PR TITLE
fix: match circuit relay address without target peer id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@
  */
 
 import { CODE_P2P, CODE_DNS4, CODE_DNS6, CODE_DNSADDR, CODE_DNS, CODE_IP4, CODE_IP6, CODE_TCP, CODE_UDP, CODE_QUIC, CODE_QUIC_V1, CODE_WS, CODE_WSS, CODE_TLS, CODE_SNI, CODE_WEBRTC_DIRECT, CODE_CERTHASH, CODE_WEBTRANSPORT, CODE_P2P_CIRCUIT, CODE_WEBRTC, CODE_HTTP, CODE_UNIX, CODE_HTTPS, CODE_MEMORY, CODE_IP6ZONE, CODE_IPCIDR } from '@multiformats/multiaddr'
-import { and, or, optional, fmt, code, value } from './utils.js'
+import { and, or, optional, fmt, code, value, not } from './utils.js'
 import type { Multiaddr, Component } from '@multiformats/multiaddr'
 
 /**
@@ -406,7 +406,7 @@ const _P2P = or(
  */
 export const P2P = fmt(_P2P)
 
-const _Circuit = and(_P2P, code(CODE_P2P_CIRCUIT), value(CODE_P2P))
+const _Circuit = and(optional(_P2P), code(CODE_P2P_CIRCUIT), not(code(CODE_WEBRTC)), optional(value(CODE_P2P)))
 
 /**
  * Matches circuit relay addresses

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,6 +53,24 @@ export const value = (code: number, value?: string): Matcher => {
 }
 
 /**
+ * Matches a multiaddr component with the specified code and value. If the value
+ * is omitted any non-undefined value is matched.
+ */
+export const not = (matcher: Matcher): Matcher => {
+  return {
+    match: (vals) => {
+      const result = matcher.match(vals)
+
+      if (result === false) {
+        return vals
+      }
+
+      return false
+    }
+  }
+}
+
+/**
  * An optional matcher
  */
 export const optional = (matcher: Matcher): Matcher => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -234,7 +234,7 @@ describe('multiaddr matcher', () => {
     '/dnsaddr/ipfs.io/ws',
     '/ip4/1.2.3.4/tcp/3456/http/p2p-webrtc-star',
     '/ip4/0.0.0.0/tcp/12345/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj/p2p-circuit/webrtc',
-    '/ip4/0.0.0.0/tcp/12345/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj/p2p-circuit/webrtc/p2p/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79',
+    '/ip4/0.0.0.0/tcp/12345/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj/p2p-circuit/webrtc/p2p/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79'
   ]
 
   const goodIPFS = [

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -214,6 +214,7 @@ describe('multiaddr matcher', () => {
   ]
 
   const goodCircuit = [
+    '/ip4/0.0.0.0/tcp/12345/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj/p2p-circuit',
     '/ip4/0.0.0.0/tcp/12345/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj/p2p-circuit/p2p/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79',
     '/ip4/0.0.0.0/tcp/12345/p2p-circuit/p2p/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79',
     '/dns/example.org/ws/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj/p2p-circuit/p2p/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79',
@@ -231,7 +232,9 @@ describe('multiaddr matcher', () => {
     '/ip4/0.0.7.6/udp/1234',
     '/ip6/::/udp/0/utp',
     '/dnsaddr/ipfs.io/ws',
-    '/ip4/1.2.3.4/tcp/3456/http/p2p-webrtc-star'
+    '/ip4/1.2.3.4/tcp/3456/http/p2p-webrtc-star',
+    '/ip4/0.0.0.0/tcp/12345/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj/p2p-circuit/webrtc',
+    '/ip4/0.0.0.0/tcp/12345/ipfs/QmUjNmr8TgJCn1Ao7DvMy4cjoZU15b9bwSCBLE3vwXiwgj/p2p-circuit/webrtc/p2p/QmTysQQiTGMdfRsDQp516oZ9bR3FiSCDnicUnqny2q1d79',
   ]
 
   const goodIPFS = [


### PR DESCRIPTION
Sometimes the target peer id is in the context of the invocation, for example a PeerInfo object doesn't have the peer id of the peer appended to every multiaddr as it is a waste of space.