### PR TITLE
fix: detect http/https addresses with paths and optional ports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@
  * ```
  */
 
-import { CODE_P2P, CODE_DNS4, CODE_DNS6, CODE_DNSADDR, CODE_DNS, CODE_IP4, CODE_IP6, CODE_TCP, CODE_UDP, CODE_QUIC, CODE_QUIC_V1, CODE_WS, CODE_WSS, CODE_TLS, CODE_SNI, CODE_WEBRTC_DIRECT, CODE_CERTHASH, CODE_WEBTRANSPORT, CODE_P2P_CIRCUIT, CODE_WEBRTC, CODE_HTTP, CODE_UNIX, CODE_HTTPS, CODE_MEMORY, CODE_IP6ZONE, CODE_IPCIDR } from '@multiformats/multiaddr'
+import { CODE_P2P, CODE_DNS4, CODE_DNS6, CODE_DNSADDR, CODE_DNS, CODE_IP4, CODE_IP6, CODE_TCP, CODE_UDP, CODE_QUIC, CODE_QUIC_V1, CODE_WS, CODE_WSS, CODE_TLS, CODE_SNI, CODE_WEBRTC_DIRECT, CODE_CERTHASH, CODE_WEBTRANSPORT, CODE_P2P_CIRCUIT, CODE_WEBRTC, CODE_HTTP, CODE_UNIX, CODE_HTTPS, CODE_MEMORY, CODE_IP6ZONE, CODE_IPCIDR, CODE_HTTP_PATH } from '@multiformats/multiaddr'
 import { and, or, optional, fmt, code, value, not } from './utils.js'
 import type { Multiaddr, Component } from '@multiformats/multiaddr'
 
@@ -442,10 +442,7 @@ const _WebRTC = or(
  */
 export const WebRTC = fmt(_WebRTC)
 
-const _HTTP = or(
-  and(_IP_OR_DOMAIN, value(CODE_TCP), code(CODE_HTTP), optional(value(CODE_P2P))),
-  and(_IP_OR_DOMAIN, code(CODE_HTTP), optional(value(CODE_P2P)))
-)
+const _HTTP = and(_IP_OR_DOMAIN, not(value(CODE_UDP)), optional(value(CODE_TCP)), optional(code(CODE_HTTP)), optional(value(CODE_HTTP_PATH)), optional(value(CODE_P2P)))
 
 /**
  * Matches HTTP addresses
@@ -468,8 +465,7 @@ const _HTTPS = and(_IP_OR_DOMAIN, or(
   and(code(CODE_TLS), code(CODE_HTTP)),
   code(CODE_TLS),
   code(CODE_HTTPS)
-),
-optional(value(CODE_P2P))
+), optional(value(CODE_HTTP_PATH)), optional(value(CODE_P2P))
 )
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -464,6 +464,7 @@ const _HTTP = and(_IP_OR_DOMAIN, or(
 export const HTTP = fmt(_HTTP)
 
 const _HTTPS = and(_IP_OR_DOMAIN, or(
+  and(value(CODE_TCP, '443')),
   and(value(CODE_TCP, '443'), code(CODE_HTTP)),
   and(value(CODE_TCP), code(CODE_HTTPS)),
   and(value(CODE_TCP), code(CODE_TLS), code(CODE_HTTP)),

--- a/src/index.ts
+++ b/src/index.ts
@@ -442,7 +442,12 @@ const _WebRTC = or(
  */
 export const WebRTC = fmt(_WebRTC)
 
-const _HTTP = and(_IP_OR_DOMAIN, not(value(CODE_UDP)), optional(value(CODE_TCP)), optional(code(CODE_HTTP)), optional(value(CODE_HTTP_PATH)), optional(value(CODE_P2P)))
+const _HTTP = and(_IP_OR_DOMAIN, or(
+  and(value(CODE_TCP, '80')),
+  and(value(CODE_TCP), code(CODE_HTTP)),
+  code(CODE_HTTP)
+), optional(value(CODE_HTTP_PATH)), optional(value(CODE_P2P))
+)
 
 /**
  * Matches HTTP addresses

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -337,7 +337,12 @@ describe('multiaddr matcher', () => {
     '/dns6/example.org/tcp/80/http',
     '/dnsaddr/example.org/tcp/80/http',
     '/dns/example.org/tcp/7777/http',
-    '/dns/example.org/tcp/7777/http/p2p/12D3KooWQF6Q3i1QkziJQ9mkNNcyFD8GPQz6R6oEvT75wgsVXm4v'
+    '/dns/example.org/tcp/7777/http/p2p/12D3KooWQF6Q3i1QkziJQ9mkNNcyFD8GPQz6R6oEvT75wgsVXm4v',
+    '/dns/trustless-gateway.link',
+    '/dns/trustless-gateway.link/tcp/80',
+    '/dns/trustless-gateway.link/http',
+    '/dns/trustless-gateway.link/tcp/443/http/http-path/ipfs%2Fbafybeigocr7lc57bjw3b7jkv2y3mtggcvfiebs5wq5b7epfwtb5wgwgzm4%3Fformat%3Draw'
+
   ]
 
   const goodHTTP = [
@@ -364,7 +369,8 @@ describe('multiaddr matcher', () => {
     '/dns/example.org/tcp/7777/tls/http',
     '/dns/example.org/tcp/443/tls/http',
     '/dns4/example.org/tls/http',
-    '/dns/example.org/tls/http/p2p/12D3KooWQF6Q3i1QkziJQ9mkNNcyFD8GPQz6R6oEvT75wgsVXm4v'
+    '/dns/example.org/tls/http/p2p/12D3KooWQF6Q3i1QkziJQ9mkNNcyFD8GPQz6R6oEvT75wgsVXm4v',
+    '/dns/trustless-gateway.link/tcp/443/tls/http/http-path/ipfs%2Fbafybeigocr7lc57bjw3b7jkv2y3mtggcvfiebs5wq5b7epfwtb5wgwgzm4%3Fformat%3Draw'
   ]
 
   const goodHTTPS = [

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -338,9 +338,11 @@ describe('multiaddr matcher', () => {
     '/dnsaddr/example.org/tcp/80/http',
     '/dns/example.org/tcp/7777/http',
     '/dns/example.org/tcp/7777/http/p2p/12D3KooWQF6Q3i1QkziJQ9mkNNcyFD8GPQz6R6oEvT75wgsVXm4v',
-    '/dns/trustless-gateway.link',
     '/dns/trustless-gateway.link/tcp/80',
+    '/dns/trustless-gateway.link/tcp/1234/http',
     '/dns/trustless-gateway.link/http',
+    '/dns/trustless-gateway.link/http/http-path/ipfs%2Fbafybeigocr7lc57bjw3b7jkv2y3mtggcvfiebs5wq5b7epfwtb5wgwgzm4%3Fformat%3Draw',
+    '/dns/trustless-gateway.link/http/http-path/ipfs%2Fbafybeigocr7lc57bjw3b7jkv2y3mtggcvfiebs5wq5b7epfwtb5wgwgzm4%3Fformat%3Draw/p2p/12D3KooWQF6Q3i1QkziJQ9mkNNcyFD8GPQz6R6oEvT75wgsVXm4v',
     '/dns/trustless-gateway.link/tcp/443/http/http-path/ipfs%2Fbafybeigocr7lc57bjw3b7jkv2y3mtggcvfiebs5wq5b7epfwtb5wgwgzm4%3Fformat%3Draw'
 
   ]

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -338,12 +338,12 @@ describe('multiaddr matcher', () => {
     '/dnsaddr/example.org/tcp/80/http',
     '/dns/example.org/tcp/7777/http',
     '/dns/example.org/tcp/7777/http/p2p/12D3KooWQF6Q3i1QkziJQ9mkNNcyFD8GPQz6R6oEvT75wgsVXm4v',
-    '/dns/trustless-gateway.link/tcp/80',
-    '/dns/trustless-gateway.link/tcp/1234/http',
-    '/dns/trustless-gateway.link/http',
-    '/dns/trustless-gateway.link/http/http-path/ipfs%2Fbafybeigocr7lc57bjw3b7jkv2y3mtggcvfiebs5wq5b7epfwtb5wgwgzm4%3Fformat%3Draw',
-    '/dns/trustless-gateway.link/http/http-path/ipfs%2Fbafybeigocr7lc57bjw3b7jkv2y3mtggcvfiebs5wq5b7epfwtb5wgwgzm4%3Fformat%3Draw/p2p/12D3KooWQF6Q3i1QkziJQ9mkNNcyFD8GPQz6R6oEvT75wgsVXm4v',
-    '/dns/trustless-gateway.link/tcp/443/http/http-path/ipfs%2Fbafybeigocr7lc57bjw3b7jkv2y3mtggcvfiebs5wq5b7epfwtb5wgwgzm4%3Fformat%3Draw'
+    '/dns/example.org/tcp/80',
+    '/dns/example.org/tcp/1234/http',
+    '/dns/example.org/http',
+    '/dns/example.org/http/http-path/ipfs%2Fbafybeigocr7lc57bjw3b7jkv2y3mtggcvfiebs5wq5b7epfwtb5wgwgzm4%3Fformat%3Draw',
+    '/dns/example.org/http/http-path/ipfs%2Fbafybeigocr7lc57bjw3b7jkv2y3mtggcvfiebs5wq5b7epfwtb5wgwgzm4%3Fformat%3Draw/p2p/12D3KooWQF6Q3i1QkziJQ9mkNNcyFD8GPQz6R6oEvT75wgsVXm4v',
+    '/dns/example.org/tcp/443/http/http-path/ipfs%2Fbafybeigocr7lc57bjw3b7jkv2y3mtggcvfiebs5wq5b7epfwtb5wgwgzm4%3Fformat%3Draw'
 
   ]
 
@@ -364,6 +364,7 @@ describe('multiaddr matcher', () => {
     '/dns6/example.org/tcp/80/https',
     '/dnsaddr/example.org/tcp/80/https',
     '/dns/example.org/tcp/7777/https',
+    '/dns/example.org/tcp/443',
     '/dns4/example.org/tcp/443/http',
     '/dns6/example.org/tcp/443/http',
     '/dnsaddr/example.org/tcp/443/http',
@@ -372,7 +373,7 @@ describe('multiaddr matcher', () => {
     '/dns/example.org/tcp/443/tls/http',
     '/dns4/example.org/tls/http',
     '/dns/example.org/tls/http/p2p/12D3KooWQF6Q3i1QkziJQ9mkNNcyFD8GPQz6R6oEvT75wgsVXm4v',
-    '/dns/trustless-gateway.link/tcp/443/tls/http/http-path/ipfs%2Fbafybeigocr7lc57bjw3b7jkv2y3mtggcvfiebs5wq5b7epfwtb5wgwgzm4%3Fformat%3Draw'
+    '/dns/example.org/tcp/443/tls/http/http-path/ipfs%2Fbafybeigocr7lc57bjw3b7jkv2y3mtggcvfiebs5wq5b7epfwtb5wgwgzm4%3Fformat%3Draw'
   ]
 
   const goodHTTPS = [


### PR DESCRIPTION
Expand the definition of http/https addresses to support optional http paths and ports.